### PR TITLE
Fix misc bugs in Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # freecodecamp-twitch
-FreeCodeCamp: Use the Twitchtv JSON API
+[FreeCodeCamp: Use the Twitchtv JSON API](https://codepen.io/shgysk8zer0/full/yzbmdy/)
 
 - - -
 [![license](https://img.shields.io/github/license/shgysk8zer0/freecodecamp-twitch.svg)](./LICENSE)

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,4 @@
+import './shims.js';
 import {$} from './std-js/functions.js';
 import Twitch from './Twitch.js';
 import {userList, twitchUrl} from './consts.js';
@@ -18,9 +19,11 @@ $(self).ready(async () => {
 		}
 	});
 
-	$('[data-show]').click(click => $('[data-visible]').each(el => {
-		el.dataset.visible = click.target.dataset.show;
-	}));
+	$('[data-show]').click(function() {
+		$('[data-visible]').each(el => {
+			el.dataset.visible = this.dataset.show;
+		});
+	});
 
 	const list = document.querySelector('.twitch-list');
 	const users = await Twitch.getUsers(...userList);

--- a/js/shims.js
+++ b/js/shims.js
@@ -1,0 +1,8 @@
+if (! DOMTokenList.prototype.hasOwnProperty('replace')) {
+	DOMTokenList.prototype.replace = function(cname1, cname2) {
+		if (this.contains(cname1)) {
+			this.remove(cname1);
+			this.add(cname2);
+		}
+	};
+}


### PR DESCRIPTION
Chrome does not support `DOMTokenList.prototype.replace`, and does not handle click handlers using arrow notation very well.

Fix that.

Also adds CodePen link to README.